### PR TITLE
lightreduce -> carryPropagate

### DIFF
--- a/internal/radix51/fe_mul.go
+++ b/internal/radix51/fe_mul.go
@@ -104,5 +104,5 @@ func (v *FieldElement) Mul(x, y *FieldElement) *FieldElement {
 	// finally from r_4 to r_0 . Each of these carries is done as one copy, one
 	// right shift by 51, one logical and with 2^51 − 1, and one addition.
 	*v = FieldElement{r00, r10, r20, r30, r40}
-	return v.lightReduce1().lightReduce2()
+	return v.carryPropagate1().carryPropagate2()
 }

--- a/internal/radix51/fe_square.go
+++ b/internal/radix51/fe_square.go
@@ -78,5 +78,5 @@ func (v *FieldElement) Square(x *FieldElement) *FieldElement {
 	r00 += r41
 
 	*v = FieldElement{r00, r10, r20, r30, r40}
-	return v.lightReduce1().lightReduce2()
+	return v.carryPropagate1().carryPropagate2()
 }


### PR DESCRIPTION
In [this line](https://github.com/gtank/ristretto255/blob/master/internal/radix51/fe_mul.go#L107) and [this one](https://github.com/gtank/ristretto255/blob/master/internal/radix51/fe_square.go#L81), they need `lightReduce` defined, but its used elsewhere as `carryPropagate`.