### PR TITLE
ristretto255: add Set() to Scalar and Element types

### DIFF
--- a/ristretto255.go
+++ b/ristretto255.go
@@ -46,6 +46,12 @@ func NewElement() *Element {
 	return (&Element{}).Zero()
 }
 
+// Set sets the value of e to x and returns e.
+func (e *Element) Set(x *Element) *Element {
+	*e = *x
+	return e
+}
+
 // Equal returns 1 if e is equivalent to ee, and 0 otherwise.
 //
 // Note that Elements must not be compared in any other way.

--- a/ristretto255_test.go
+++ b/ristretto255_test.go
@@ -303,3 +303,62 @@ func TestMarshalElement(t *testing.T) {
 		t.Fatalf("Error unmarshaling element from json: %s %v", text, err)
 	}
 }
+
+func TestElementSet(t *testing.T) {
+	// Test this, because the internal point type being hard-copyable isn't part of the spec.
+
+	el1 := NewElement().Zero()
+	el2 := NewElement().Base()
+
+	if el1.Equal(el2) == 1 {
+		t.Error("shouldn't be the same")
+	}
+
+	// Check new value
+	el1.Set(el2)
+
+	if el1.Equal(el2) == 0 {
+		t.Error("failed to set the value")
+	}
+
+	// Mutate source var
+	el2.Add(el2, el2)
+
+	if el1.Equal(el2) == 1 {
+		t.Error("shouldn't have changed")
+	}
+}
+
+func TestScalarSet(t *testing.T) {
+	// Test this, because the internal scalar representation being hard-copyable isn't part of the spec.
+
+	// 32-byte little endian value of "1"
+	scOne := make([]byte, 32)
+	scOne[0] = 0x01
+
+	sc1, sc2 := NewScalar(), NewScalar().Zero()
+
+	// sc1 <- 1
+	sc1.Decode(scOne)
+
+	// 1 != 0
+	if sc1.Equal(sc2) == 1 {
+		t.Error("shouldn't be the same")
+	}
+
+	// sc2 <- sc1
+	sc2.Set(sc1)
+
+	// 1 == 1
+	if sc1.Equal(sc2) == 0 {
+		t.Error("failed to set the value")
+	}
+
+	// sc1 <- 1 + 1
+	sc1.Add(sc1, sc1)
+
+	// 2 != 1
+	if sc1.Equal(sc2) == 1 {
+		t.Error("shouldn't have changed")
+	}
+}

--- a/scalar.go
+++ b/scalar.go
@@ -23,7 +23,7 @@ func NewScalar() *Scalar {
 	return (&Scalar{}).Zero()
 }
 
-// Set sets the value of e to x and returns e.
+// Set sets the value of s to x and returns s.
 func (s *Scalar) Set(x *Scalar) *Scalar {
 	*s = *x
 	return s

--- a/scalar.go
+++ b/scalar.go
@@ -6,6 +6,7 @@ package ristretto255
 
 import (
 	"encoding/base64"
+
 	"github.com/gtank/ristretto255/internal/scalar"
 )
 
@@ -20,6 +21,12 @@ type Scalar struct {
 // NewScalar returns a Scalar set to the value 0.
 func NewScalar() *Scalar {
 	return (&Scalar{}).Zero()
+}
+
+// Set sets the value of e to x and returns e.
+func (s *Scalar) Set(x *Scalar) *Scalar {
+	*s = *x
+	return s
 }
 
 // Add sets s = x + y mod l and returns s.


### PR DESCRIPTION
This allows an easier `Clone` pattern than round-tripping through bytes and closes #35.